### PR TITLE
fixed broken link typo within the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ the environment variables in `cloud-run.yml` to work for your team's GCP project
 First, deploy your project manually from the command line.
 
 1. Set up your Google Cloud Project by following the "Before you begin" section of 
-http://cloud/run/docs/quickstarts/build-and-deploy/deploy-python-service?hl=en. **Each student can do this with their own Cloud project to start.**
+https://cloud.google.com/run/docs/quickstarts/build-and-deploy/deploy-python-service?hl=en. **Each student can do this with their own Cloud project to start.**
 
 2. Build the image using the following commands, replacing the project ID and service 
 name with your info. Your service name is the name of your webapp or project and can 


### PR DESCRIPTION
https://cloud.google.com/run/docs/quickstarts/build-and-deploy/deploy-python-service?hl=en

link was missing the '.google.com' portion of the domain.